### PR TITLE
Add Japanese sample data for WARC tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ raw_samples.txt
 *.txt
 *.warc
 ut1_blocklist
+# allow sample WARC for tests
+!testdata/sample.warc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# cc-parser
+
+This repository contains a simple Rust program for parsing Common Crawl WARC files.
+
+## Test Data
+
+The `testdata/sample.warc` file provides a small concatenated WARC with four
+response records. Two records are short HTML snippets from example domains in
+English. The other two include Japanese text to better simulate real pages.
+All content was written for testing purposes so that no licensed material is
+included.
+
+You can use this file to run local tests of the parser without downloading
+external resources.

--- a/testdata/sample.warc
+++ b/testdata/sample.warc
@@ -1,0 +1,63 @@
+WARC/1.0
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:4ab621bd-7506-466a-afcf-a9026e2ee465>
+WARC-Target-URI: http://example.com/
+WARC-Date: 2024-01-01T00:00:00Z
+Content-Length: 96
+Content-Type: application/http; msgtype=response
+
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=UTF-8
+
+<html><body>Hello World</body></html>
+
+WARC/1.0
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:c7ce0061-8e52-4b58-b6dc-1d7d98e2004e>
+WARC-Target-URI: http://example.org/
+WARC-Date: 2024-01-01T00:00:00Z
+Content-Length: 96
+Content-Type: application/http; msgtype=response
+
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=UTF-8
+
+<html><body>Second Page</body></html>
+
+WARC/1.0
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:1c3b1c38-abd9-4d1b-9451-a11111111111>
+WARC-Target-URI: http://example.jp/
+WARC-Date: 2024-01-01T00:00:00Z
+Content-Length: 244
+Content-Type: application/http; msgtype=response
+
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=UTF-8
+
+<html lang="ja">
+<body>
+<p>こんにちは、これはサンプルの日本語ページです。</p>
+<p>テストのためのコンテンツが含まれています。</p>
+</body>
+</html>
+
+WARC/1.0
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:2d4e2c11-0000-4f3c-bbbb-b22222222222>
+WARC-Target-URI: http://example.net/
+WARC-Date: 2024-01-01T00:00:00Z
+Content-Length: 334
+Content-Type: application/http; msgtype=response
+
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=UTF-8
+
+<html lang="ja">
+<head><title>サンプルページ</title></head>
+<body>
+<h1>日本語のテスト</h1>
+<p>このページはCommon Crawlのテスト用に作成されています。</p>
+<p>実際のサイトから取得したものではありません。</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand the sample WARC with two Japanese pages for more realistic test data
- update README to describe the additional content

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_683be59c19f0832db962dc92208bcc48