### PR TITLE
Add sample WARC for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ raw_samples.txt
 *.txt
 *.warc
 ut1_blocklist
+# allow sample WARC for tests
+!cc-data/
+!cc-data/warc/
+!cc-data/warc/sample.warc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# cc-parser
+
+This repository contains a simple Rust program for parsing Common Crawl WARC files.
+
+## Test Data
+
+The `cc-data/warc/sample.warc` file provides a minimal concatenated WARC with two
+response records. Each record includes a small HTML snippet served from an
+example domain. The content is intentionally simple and does not contain any
+copyrighted or restricted data.
+
+You can use this file to run local tests of the parser without downloading
+external resources.

--- a/cc-data/warc/sample.warc
+++ b/cc-data/warc/sample.warc
@@ -1,0 +1,25 @@
+WARC/1.0
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:4ab621bd-7506-466a-afcf-a9026e2ee465>
+WARC-Target-URI: http://example.com/
+WARC-Date: 2024-01-01T00:00:00Z
+Content-Length: 96
+Content-Type: application/http; msgtype=response
+
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=UTF-8
+
+<html><body>Hello World</body></html>
+
+WARC/1.0
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:c7ce0061-8e52-4b58-b6dc-1d7d98e2004e>
+WARC-Target-URI: http://example.org/
+WARC-Date: 2024-01-01T00:00:00Z
+Content-Length: 96
+Content-Type: application/http; msgtype=response
+
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=UTF-8
+
+<html><body>Second Page</body></html>


### PR DESCRIPTION
## Summary
- provide a small concatenated WARC file for parser tests
- document the sample data in a new README
- allow the test WARC to be committed by updating `.gitignore`

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_683be59c19f0832db962dc92208bcc48